### PR TITLE
Add Plug.Conn as first argument to controller functions

### DIFF
--- a/lib/facebook_callback.ex
+++ b/lib/facebook_callback.ex
@@ -7,16 +7,16 @@ defmodule FacebookMessenger.Callback do
   @doc """
   function called when a message is received from facebook
   """
-  @callback message_received(FacebookMessenger.Response) :: any
+  @callback message_received(Plug.Conn.t, FacebookMessenger.Response) :: any
 
   @doc """
   called when a challenge has been received from facebook and the challenge succeeeded
   """
-  @callback challenge_successfull(any) :: any
+  @callback challenge_successful(Plug.Conn.t, any) :: any
 
   @doc """
   called when a challenge has been received from facebook and the challenge failed
   """
-  @callback challenge_failed(any) :: any
+  @callback challenge_failed(Plug.Conn.t, any) :: any
 
 end

--- a/lib/facebook_responder.ex
+++ b/lib/facebook_responder.ex
@@ -1,4 +1,3 @@
-
 defmodule FacebookMessenger.Responder do
   @moduledoc """
   Module responsilbe for responding back to phoenix plug
@@ -13,6 +12,6 @@ defmodule FacebookMessenger.Responder.Mock do
   Mock Module responsilbe for responding back to phoenix plug
   """
   def respond(%{request_path: request_path, status: status, resp_body: resp_body}) do
-    send(self, {request_path, status, resp_body})
+    send(self(), {request_path, status, resp_body})
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule FacebookMessenger.Phoenix.Mixfile do
      if Mix.env == :test do
       [{:coverex, "~> 1.4.8", only: :test}, {:poison, "~> 2.1.0", override: true} | d]
     else
-      [{:poison, "~> 2.1.0"} | d]
+      [{:poison, "~> 2.1.0 or ~> 3.0"} | d]
     end
   end
 

--- a/test/message_controller_test.exs
+++ b/test/message_controller_test.exs
@@ -2,7 +2,7 @@
 defmodule TestController do
   use FacebookMessenger.Phoenix.Controller
 
-  def message_received(msg) do
+  def message_received(%Plug.Conn{}, msg) do
     text = FacebookMessenger.Response.message_texts(msg) |> hd
     sender = FacebookMessenger.Response.message_senders(msg) |> hd
     FacebookMessenger.Sender.send(sender, text)
@@ -32,8 +32,8 @@ defmodule FacebookMessenger.Phoenix.Controller.Test do
     defmodule TestController2 do
       use FacebookMessenger.Phoenix.Controller
 
-      def challenge_successfull(params) do
-        send(self, 1)
+      def challenge_successful(_conn, _params) do
+        send(self(), 1)
       end
     end
 
@@ -48,8 +48,8 @@ defmodule FacebookMessenger.Phoenix.Controller.Test do
     defmodule TestController2 do
       use FacebookMessenger.Phoenix.Controller
 
-      def challenge_failed(params) do
-        send(self, 2)
+      def challenge_failed(_conn, params) do
+        send(self(), 2)
       end
     end
 


### PR DESCRIPTION
This allows for a more flexible implementation of the Facebook challenge (e.g. where the challenge / response comes from the database instead of the application env, based on the url).

The `message_received` also gets a Conn passed in so that you can have multiple bots running in one project.

Furthermore I changed the typo `challenge_successfull` to `challenge_successful`.